### PR TITLE
Correctly quote repo= when adding items

### DIFF
--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -2,7 +2,7 @@
 
 - name: Adding apt repository
   apt_repository: >
-    repo={{ item }}
+    repo="{{ item }}"
     update_cache=yes
   with_items: apt_repositories
   tags:


### PR DESCRIPTION
Because repository can be a string that includes spaces it needs to be
quoted to prevent ansible failing.

This adds those quotation marks with no other changes.
