### PR TITLE
Add support for adding apt signing keys

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,5 @@ apt_install_suggests: false
 apt_install_recommends: false
 # repositories to register
 apt_repositories: []
+# gpg keys for external repositories
+apt_keys: []

--- a/tasks/keys.yml
+++ b/tasks/keys.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Adding apt signing key
+  apt_key: >
+    url="{{ item }}"
+    state=present
+  with_items: apt_keys
+  tags:
+    - system
+    - apt
+    - keys

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - include: dependencies.yml
+- include: keys.yml
 - include: repositories.yml
 - include: update.yml
 - include: cleanup.yml


### PR DESCRIPTION
This is basically a copy of apt_repositories but adjusted to handle
keys instead. It sits before repositories since it can't refresh on
its own but the keys need to be loaded before apt runs next.

This is necessary if using an apt repository thats not in the distributions keyring.
