### PR TITLE
Configure apt (install template) before running any package affecting operations

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
+- include: config.yml
 - include: dependencies.yml
 - include: repositories.yml
 - include: update.yml
 - include: cleanup.yml
-- include: config.yml
 - include: packages.yml


### PR DESCRIPTION
Although its impact is generally minor, apt-get dist-upgrade does recognise
--no-install-recommends and acts accordingly. Since its assumed recommends
are not desirable at all the config is now installed before the ansible apt
dependencies ensuring it happens before all upgrades/installs/removals/etc.

The previous configuration meant it was installed between the first upgrade and packages being installed but on subsequent runs it would affect both upgrades and installs.

I've not tested to see how this affects the apt modules bring up on a clean system but this role appears to install the packages it needs explicitly.
