### PR TITLE
Only remove packages if installs occur

### DIFF
--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -3,6 +3,7 @@
 - name: Removing packages that are no longer needed for dependencies
   shell: apt-get -y autoremove
   when: apt_autoremove
+  when: aptupgrade.changed or aptinstalls.changed
   tags:
     - system
     - apt
@@ -11,6 +12,7 @@
 - name: Removing .deb files for packages no longer on your system
   shell: apt-get -y autoclean
   when: apt_autoclean
+  when: aptupgrade.changed or aptinstalls.changed
   tags:
     - system
     - apt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,6 @@
 - include: dependencies.yml
 - include: repositories.yml
 - include: update.yml
-- include: cleanup.yml
 - include: config.yml
 - include: packages.yml
+- include: cleanup.yml

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -5,6 +5,7 @@
     pkg={{ item }}
     state=present
   with_items: apt_packages
+  register: aptinstalls
   tags:
     - system
     - apt

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -14,6 +14,7 @@
   apt: >
     upgrade={{apt_upgrade}}
   when: apt_upgrade == "safe" or apt_upgrade == "full" or apt_upgrade == "dist"
+  register: aptupgrade
   tags:
     - system
     - apt


### PR DESCRIPTION
This code change means package cleanup will only be run if packages
are installed or upgraded - the most likely reason for those files
to be out of date.

I've tested with no change and with a package install - both seemed
 to work correctly but its not a very comprehensive test.
