### PR TITLE
Add variable to have apt mount root read write

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ apt_autoclean: yes
 apt_install_suggests: false
 # whether or not recommended packages should be installed.
 apt_install_recommends: false
+# remount root filesystem r/w before running if mounted r/o
+apt_remount_filesystem: false
 # repositories to register
 apt_repositories: []
 # gpg keys for external repositories

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ apt_autoclean: yes
 apt_install_suggests: false
 # whether or not recommended packages should be installed.
 apt_install_recommends: false
+# remount root filesystem r/w before running if mounted r/o
+apt_remount_filesystem: false
 # repositories to register
 apt_repositories: []
 # gpg keys for external repositories

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,3 +11,17 @@
     - system
     - apt
     - config
+
+- name: Configure to remount read only root filesystems
+  template: >
+    src=etc-apt-apt-conf-d-10-remount-readonly-filesystems.j2
+    dest=/etc/apt/apt.conf.d/10remount-readonly-filesystems
+    owner=root
+    group=root
+    mode=0644
+  when: apt_remount_filesystem
+  tags:
+    - system
+    - apt
+    - config
+

--- a/templates/etc-apt-apt-conf-d-10-remount-readonly-filesystems.j2
+++ b/templates/etc-apt-apt-conf-d-10-remount-readonly-filesystems.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+DPkg {
+    // Auto re-mounting of a readonly /
+    Pre-Invoke { "mount -o remount,rw LABEL=ROOTFS /"; };
+    Post-Invoke { "test ${NO_APT_REMOUNT:-no} = yes || mount -o remount,ro LABEL=ROOTFS / || true"; };
+};
+


### PR DESCRIPTION
In cases where you have a read only root filesystem a snippet like this is
required to ensure apt is able to run correctly.

Obviously if /usr is on another filesystem that would need a fragment too but I
don't have a setup like that to test with.

The fragment originates at https://wiki.debian.org/ReadonlyRoot#Make_apt-get_remount_.2F_if_needed
