### PR TITLE
Https proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,6 @@ apt_remount_filesystem:
 apt_repositories: []
 # gpg keys for external repositories
 apt_keys: []
-
-# HTTP proxy server
-apt_http_proxy_address:
-# HTTP pipeline depth
-apt_http_pipeline_depth: 5
-
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,10 +72,3 @@ apt_remount_filesystem:
 apt_repositories: []
 # gpg keys for external repositories
 apt_keys: []
-
-# HTTP proxy server
-apt_http_proxy_address:
-# HTTPS proxy server
-apt_https_proxy_address:
-# HTTP pipeline depth
-apt_http_pipeline_depth: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,5 +75,7 @@ apt_keys: []
 
 # HTTP proxy server
 apt_http_proxy_address:
+# HTTPS proxy server
+apt_https_proxy_address:
 # HTTP pipeline depth
 apt_http_pipeline_depth: 5

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -40,6 +40,6 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  when: apt_http_proxy_address
+  when: apt_http_proxy_address is defined
   with_items:
     - "etc/apt/apt.conf.d/00proxy"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -40,6 +40,6 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  when: apt_http_proxy_address is defined
+  when: apt_http_proxy_address is defined or apt_https_proxy_address is defined
   with_items:
     - "etc/apt/apt.conf.d/00proxy"

--- a/templates/etc/apt/apt.conf.d/00proxy.j2
+++ b/templates/etc/apt/apt.conf.d/00proxy.j2
@@ -1,11 +1,11 @@
 // {{ ansible_managed }}
 
-{% if apt_http_proxy_address is defined %}
+{% if apt_http_proxy_address is defined and not apt_http_proxy_address %}
 Acquire::http::Proxy "{{ apt_http_proxy_address }}";
 {% endif %}
-{% if apt_https_proxy_address is defined %}
+{% if apt_https_proxy_address is defined and not apt_https_proxy_address %}
 Acquire::https::Proxy "{{ apt_https_proxy_address }}";
 {% endif %}
-{% if apt_http_pipeline_depth is defined %}
+{% if apt_http_pipeline_depth is defined and not apt_http_pipeline_depth %}
 Acquire::http::Pipeline-Depth "{{ apt_http_pipeline_depth }}";
 {% endif %}

--- a/templates/etc/apt/apt.conf.d/00proxy.j2
+++ b/templates/etc/apt/apt.conf.d/00proxy.j2
@@ -1,11 +1,11 @@
 // {{ ansible_managed }}
 
-{% if apt_http_proxy_address %}
+{% if apt_http_proxy_address is defined %}
 Acquire::http::Proxy "{{ apt_http_proxy_address }}";
 {% endif %}
-{% if apt_https_proxy_address %}
+{% if apt_https_proxy_address is defined %}
 Acquire::https::Proxy "{{ apt_https_proxy_address }}";
 {% endif %}
-{% if apt_http_pipeline_depth %}
+{% if apt_http_pipeline_depth is defined %}
 Acquire::http::Pipeline-Depth "{{ apt_http_pipeline_depth }}";
 {% endif %}

--- a/templates/etc/apt/apt.conf.d/00proxy.j2
+++ b/templates/etc/apt/apt.conf.d/00proxy.j2
@@ -4,7 +4,10 @@
 // Proxy apt communication through this HTTP proxy
 Acquire::http::Proxy "{{ apt_http_proxy_address }}";
 {% endif %}
-
+{% if apt_https_proxy_address %}
+// Proxy apt communication through this HTTP proxy
+Acquire::https::Proxy "{{ apt_https_proxy_address }}";
+{% endif %}
 {% if apt_http_pipeline_depth %}
 // Control the number of pipelined HTTP requests on a single TCP connection
 // May need to set to 0 as some proxies (Squid, etc) do not have full support

--- a/templates/etc/apt/apt.conf.d/00proxy.j2
+++ b/templates/etc/apt/apt.conf.d/00proxy.j2
@@ -1,15 +1,11 @@
 // {{ ansible_managed }}
 
 {% if apt_http_proxy_address %}
-// Proxy apt communication through this HTTP proxy
 Acquire::http::Proxy "{{ apt_http_proxy_address }}";
 {% endif %}
 {% if apt_https_proxy_address %}
-// Proxy apt communication through this HTTP proxy
 Acquire::https::Proxy "{{ apt_https_proxy_address }}";
 {% endif %}
 {% if apt_http_pipeline_depth %}
-// Control the number of pipelined HTTP requests on a single TCP connection
-// May need to set to 0 as some proxies (Squid, etc) do not have full support
 Acquire::http::Pipeline-Depth "{{ apt_http_pipeline_depth }}";
 {% endif %}


### PR DESCRIPTION
Default definition of the proxy-related variables is removed so that role consumers can disable the feature entirely.

The template now checks that not only are the variables defined, but that they are non-empty