### PR TITLE
Alter filesystem remount task

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ apt_unattended_upgrades_automatic_reboot_time: now
 # remount file system: rootfs | tmpfs
 #   tmpfs:  remount tmp before running if mounted noexec
 #   rootfs: remount root filesystem r/w before running if mounted r/o
-apt_remount_filesystem:
+apt_remount_filesystem: []
 
 # repositories to register
 apt_repositories: []

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -24,14 +24,14 @@
 
 - name: Configuring remount filesystems
   template:
-    src: "{{ item }}.j2"
+    src: "etc/apt/apt.conf.d/10remount_{{ item }}.j2"
     dest: "/{{ item }}"
     owner: "root"
     group: "root"
     mode: "0644"
   when: apt_remount_filesystem
   with_items:
-    - "etc/apt/apt.conf.d/10remount_{{ apt_remount_filesystem }}"
+    - "{{ apt_remount_filesystem }}"
 
 - name: Configuring APT proxy behavior
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -25,7 +25,7 @@
 - name: Configuring remount filesystems
   template:
     src: "etc/apt/apt.conf.d/10remount_{{ item }}.j2"
-    dest: "/{{ item }}"
+    dest: "/etc/apt/apt.conf.d/10remount_{{ item }}"
     owner: "root"
     group: "root"
     mode: "0644"

--- a/templates/etc/apt/apt.conf.d/10remount_tmpfs.j2
+++ b/templates/etc/apt/apt.conf.d/10remount_tmpfs.j2
@@ -1,7 +1,7 @@
 // {{ ansible_managed }}
 
 DPkg {
-  // Auto re-mounting of a noexec /tmp since some packages which require it
+  // Auto re-mounting of a noexec /tmp since some packages desire exec
   Pre-Invoke { "mount -o remount,exec /tmp"; };
-  Post-Invoke { "test ${NO_APT_REMOUNT:-no} = yes || mount -o remount,exec /tmp || true"; };
+  Post-Invoke { "test ${NO_APT_REMOUNT:-no} = yes || mount -o remount,noexec /tmp || true"; };
 };


### PR DESCRIPTION
Hi,
This is an updated version of the existing code which allows multiple filesystems to be remounted - and should work 'well' just by adding another template. Also fixes a bug where filesystems are remounted exec instead of no exec.

I've checked the syntax is correct by installing in containers but haven't had a chance to test it on something with demountable filesystems - I will do so when possible, hopefully in the next few days.