### PR TITLE
eliminate include deprecation warning 2

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: update.yml
-- include: upgrade.yml
-- include: dependencies.yml
+- include_tasks: update.yml
+- include_tasks: upgrade.yml
+- include_tasks: dependencies.yml

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: keys.yml
-- include: repositories.yml
-- include: packages.yml
+- include_tasks: keys.yml
+- include_tasks: repositories.yml
+- include_tasks: packages.yml


### PR DESCRIPTION
Hi Franklin,

'include' Was still in use in a few tasks files, I created this MR. The playbook runs fine without deprecation errors.

Regards, Eimert