### PR TITLE
Adds ability to install .deb packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ This is an example playbook:
     apt_packages:
       - vim
       - tree
+    apt_deb_packages:
+      - "https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_x86_64.deb"
     apt_mails:
       - root
     apt_unattended_upgrades_notify_error_only: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,8 @@ apt_packages: []
 apt_autoremove: yes
 # remove .deb files for packages no longer on your system
 apt_autoclean: yes
+# .deb packages to install.
+apt_deb_packages: []
 
 # whether or not suggested packages should be installed.
 apt_install_suggests: no

--- a/tasks/debs.yml
+++ b/tasks/debs.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Installing .deb packages
+  apt:
+    deb: "{{ item }}"
+    autoremove: "{{ apt_autoremove }}"
+  with_items: "{{ apt_deb_packages }}"

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -3,3 +3,4 @@
 - include_tasks: keys.yml
 - include_tasks: repositories.yml
 - include_tasks: packages.yml
+- include_tasks: debs.yml

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -8,6 +8,8 @@
     apt_packages:
       - vim
       - tree
+    apt_deb_packages:
+      - "https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_x86_64.deb"
     apt_mails:
       - root
     apt_unattended_upgrades_notify_error_only: no


### PR DESCRIPTION
- The apt module includes a `deb` paramater that can be used to install
  a *.deb package directly from a path or URL.
- This change adds a new include tasks file, `debs.yml` as well as a
  supporting variable and modifies the tests playbook accordingly.
- gh-18