### PR TITLE
Fix unattended-upgrades package installation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,3 +3,4 @@
 - include_tasks: update.yml
 - include_tasks: upgrade.yml
 - include_tasks: dependencies.yml
+- include_tasks: unattended_upgrades.yml

--- a/tasks/unattended_upgrades.yml
+++ b/tasks/unattended_upgrades.yml
@@ -5,15 +5,3 @@
     pkg: "unattended-upgrades"
     state: "{{ 'latest' if apt_unattended_upgrades else 'absent' }}"
   when: apt_unattended_upgrades
-
-- name: Configure unattended-upgrades
-  template:
-    src: "{{ item }}.j2"
-    dest: "/{{ item }}"
-    owner: root
-    group: root
-    mode: "0644"
-  with_items:
-    - "etc/apt/apt.conf.d/25auto-upgrades.conf"
-    - "etc/apt/apt.conf.d/50unattended-upgrades.conf"
-  when: apt_unattended_upgrades


### PR DESCRIPTION
This PR fixes the installation of the unattended-upgrades package itself (for distribs where the package isn't already installed) which was left in an orphan task file in the repo.
