### PR TITLE
Feature/update unattended template

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ apt_auto_clean_interval: 0
 
 # enable unattended-upgrades
 apt_unattended_upgrades: yes
+# list of origins patterns to control which packages are upgraded
+# replaces allowed-origins, kept for compatibility
+apt_unattended_upgrades_origins: []
+# List of allowed-origins, default value kept for compatibility
+# set to null to use origins-pattern
+apt_unattended_upgrades_allowed:
+- '"${distro_id}:${distro_codename}-security";'
 # list of packages to not update (regexp are supported)
 apt_unattended_upgrades_blacklist: []
 # Split the upgrade into the smallest possible chunks so that
@@ -127,10 +134,34 @@ apt_unattended_upgrades_autoremove: yes
 # Automatically reboot *WITHOUT CONFIRMATION*
 # if the file /var/run/reboot-required is found after the upgrade
 apt_unattended_upgrades_automatic_reboot: no
+# Automatically reboot even if there are users currently logged in.
+apt_unattended_upgrades_automatic_reboot_with_users: no
 # If automatic reboot is enabled and needed, reboot at the specific
 # time instead of immediately
 # Values: now | 02:00 | ...
 apt_unattended_upgrades_automatic_reboot_time: now
+# Enable logging to syslog.
+apt_unattended_upgrades_syslog_enable: no
+# Specify syslog facility.
+apt_unattended_upgrades_syslog_facility: "daemon"
+
+# Override download timer ? Default no
+apt_unattended_upgrades_download_timer_override: null
+# In case of override :
+# apt_unattended_upgrades_download_timer_override:
+#   on_calendar_replace: (true|false) If true, delete default system schedule. If not, default and new schedules will be merged
+#   on_calendar: new schedule, see man systemd.time.7, example : 'Mon..Fri *-*-* 6:00'
+#   randomized_delay_sec: random delay in sec
+#   persistent: (true|false)
+# See systemd.time.5 for random delay and persistent
+
+# Override upgrade timer the same way
+apt_unattended_upgrades_upgrade_timer_override: null
+# apt_unattended_upgrades_upgrade_timer_override:
+#   on_calendar_replace:
+#   on_calendar: 
+#   randomized_delay_sec: 
+#   persistent: 
 
 # remount file system: rootfs | tmpfs
 #   tmpfs:  remount tmp before running if mounted noexec

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ apt_unattended_upgrades_origins: []
 # List of allowed-origins, default value kept for compatibility
 # set to null to use origins-pattern
 apt_unattended_upgrades_allowed:
-- '"${distro_id}:${distro_codename}-security";'
+- ${distro_id}:${distro_codename}-security
 # list of packages to not update (regexp are supported)
 apt_unattended_upgrades_blacklist: []
 # Split the upgrade into the smallest possible chunks so that
@@ -143,7 +143,7 @@ apt_unattended_upgrades_automatic_reboot_time: now
 # Enable logging to syslog.
 apt_unattended_upgrades_syslog_enable: no
 # Specify syslog facility.
-apt_unattended_upgrades_syslog_facility: "daemon"
+apt_unattended_upgrades_syslog_facility: daemon
 
 # Override download timer ? Default no
 apt_unattended_upgrades_download_timer_override: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,7 @@ apt_unattended_upgrades_origins: []
 # List of allowed-origins, default value kept for compatibility
 # set to null to use origins-pattern
 apt_unattended_upgrades_allowed:
-- '"${distro_id}:${distro_codename}-security";'
+- ${distro_id}:${distro_codename}-security
 # list of packages to not update (regexp are supported)
 apt_unattended_upgrades_blacklist: []
 # Split the upgrade into the smallest possible chunks so that
@@ -90,7 +90,7 @@ apt_unattended_upgrades_automatic_reboot_time: now
 # Enable logging to syslog.
 apt_unattended_upgrades_syslog_enable: no
 # Specify syslog facility.
-apt_unattended_upgrades_syslog_facility: "daemon"
+apt_unattended_upgrades_syslog_facility: daemon
 
 # Override download timer ? Default no
 apt_unattended_upgrades_download_timer_override: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,13 @@ apt_auto_clean_interval: 0
 
 # enable unattended-upgrades
 apt_unattended_upgrades: yes
+# list of origins patterns to control which packages are upgraded
+# replaces allowed-origins, kept for compatibility
+apt_unattended_upgrades_origins: []
+# List of allowed-origins, default value kept for compatibility
+# set to null to use origins-pattern
+apt_unattended_upgrades_allowed:
+- '"${distro_id}:${distro_codename}-security";'
 # list of packages to not update (regexp are supported)
 apt_unattended_upgrades_blacklist: []
 # Split the upgrade into the smallest possible chunks so that
@@ -74,10 +81,16 @@ apt_unattended_upgrades_autoremove: yes
 # Automatically reboot *WITHOUT CONFIRMATION*
 # if the file /var/run/reboot-required is found after the upgrade
 apt_unattended_upgrades_automatic_reboot: no
+# Automatically reboot even if there are users currently logged in.
+apt_unattended_upgrades_automatic_reboot_with_users: no
 # If automatic reboot is enabled and needed, reboot at the specific
 # time instead of immediately
 # Values: now | 02:00 | ...
 apt_unattended_upgrades_automatic_reboot_time: now
+# Enable logging to syslog.
+apt_unattended_upgrades_syslog_enable: no
+# Specify syslog facility.
+apt_unattended_upgrades_syslog_facility: "daemon"
 
 # Override download timer ? Default no
 apt_unattended_upgrades_download_timer_override: null

--- a/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
+++ b/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
@@ -1,11 +1,18 @@
 // {{ ansible_managed }}
 
+// Unattended-Upgrade::Origins-Pattern controls which packages are
+// upgraded. Replace Allowed-Origins
+Unattended-Upgrade::Origins-Pattern {
+{% for origin in apt_unattended_upgrades_origins %}
+  "{{ origin }}";
+{% endfor %}
+};
+
 // Automatically upgrade packages from these (origin:archive) pairs
 Unattended-Upgrade::Allowed-Origins {
-  "${distro_id}:${distro_codename}-security";
-//"${distro_id}:${distro_codename}-updates";
-//"${distro_id}:${distro_codename}-proposed";
-//"${distro_id}:${distro_codename}-backports";
+{% for allowed in apt_unattended_upgrades_allowed %}
+  "{{ allowed }}";
+{% endfor %}
 };
 
 // List of packages to not update (regexp are supported)
@@ -50,6 +57,9 @@ Unattended-Upgrade::Remove-Unused-Dependencies "{{ apt_unattended_upgrades_autor
 //  if the file /var/run/reboot-required is found after the upgrade
 Unattended-Upgrade::Automatic-Reboot "{{ apt_unattended_upgrades_automatic_reboot | to_nice_json }}";
 
+// Automatically reboot even if there are users currently logged in.
+Unattended-Upgrade::Automatic-Reboot-WithUsers "{{ apt_unattended_upgrades_automatic_reboot_with_users | to_nice_json }}";
+
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
@@ -58,3 +68,9 @@ Unattended-Upgrade::Automatic-Reboot-Time "{{ apt_unattended_upgrades_automatic_
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";
+
+// Enable logging to syslog. Default is False
+Unattended-Upgrade::SyslogEnable "{{ apt_unattended_upgrades_syslog_enable | to_nice_json }}";
+
+// Specify syslog facility. Default is daemon
+Unattended-Upgrade::SyslogFacility "{{ apt_unattended_upgrades_syslog_facility }}";


### PR DESCRIPTION
Hello
This PR is to add few parameters in 50unattended-upgrades template.
Especially origins-pattern which is replacing allowed-origins in a more powerful and flexible manner. I kept allowed-origins default value for compatibility.
Others parameters are apt_unattended_upgrades_automatic_reboot_with_users, apt_unattended_upgrades_syslog_enable and apt_unattended_upgrades_syslog_facility
Read.me and defaults/main.yml are updated.
Would you accept to merge please ?
Thank you