### PR TITLE
Deprecation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,10 @@ apt_unattended_upgrades_upgrade_timer_override: null
 #   randomized_delay_sec: 
 #   persistent: 
 
-# remount file system: rootfs | tmpfs
+# remount file system: currently supported options are rootfs and tmpfs
 #   tmpfs:  remount tmp before running if mounted noexec
 #   rootfs: remount root filesystem r/w before running if mounted r/o
-apt_remount_filesystem:
-apt_remount_filesystems:
+apt_remount_filesystems: []
 
 # repositories to register
 apt_repositories: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,11 +110,10 @@ apt_unattended_upgrades_upgrade_timer_override: null
 #   randomized_delay_sec: 
 #   persistent: 
 
-# remount file system: rootfs | tmpfs
+# remount file system: currently supported options are rootfs and tmpfs
 #   tmpfs:  remount tmp before running if mounted noexec
 #   rootfs: remount root filesystem r/w before running if mounted r/o
-apt_remount_filesystem:
-apt_remount_filesystems:
+apt_remount_filesystems: []
 
 # repositories to register
 apt_repositories: []

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -30,18 +30,6 @@
   include_tasks: unattended_upgrades_upgrade_timer.yml
   when: apt_unattended_upgrades_upgrade_timer_override is not none
 
-# TODO to be depricated
-- name: Configuring remount filesystem
-  template:
-    src: "etc/apt/apt.conf.d/10remount_{{ item }}.j2"
-    dest: "/etc/apt/apt.conf.d/10remount_{{ item }}"
-    owner: "root"
-    group: "root"
-    mode: "0644"
-  when: apt_remount_filesystem | bool
-  with_items:
-    - "{{ apt_remount_filesystem }}"
-
 - name: Configuring remount filesystems
   template:
     src: "etc/apt/apt.conf.d/10remount_{{ item }}.j2"


### PR DESCRIPTION
I've explicitly made apt_remount_filesystems in to an empty list to solve a
"[DEPRECATION WARNING]: evaluating None as a bare variable" message, this
feature changes in 2.12.
While making that change I adjusted the description to be more explicit about
the filesystem options.

And at while doing that I've removed the backwards compatibility with
apt_remount_filesystem - it was meant to be short lived compat and due to
generating a deprecation warning of its own has now been removed.