### PR TITLE
Allows setting of individual package parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > * updates apt
 > * cleans up apt
 > * configures apt
-> * installs packages
+> * ensures packages
 > * add repositories
 > * add keys
 > * apt pinning
@@ -80,8 +80,10 @@ Here is a list of all the default variables for this role, which are also availa
 apt_cache_valid_time: 3600
 # upgrade system: safe | full | dist
 apt_upgrade: no
-# packages to install
+# packages to ensure
 apt_packages: []
+# package state
+apt_package_state: 'present'
 # remove packages that are no longer needed for dependencies
 apt_autoremove: yes
 # remove .deb files for packages no longer on your system
@@ -225,7 +227,11 @@ This is an example playbook:
     apt_packages:
       - vim
       - tree
-      - ca-certificates
+      - name: ca-certificates
+        state: latest
+      - name: zsh
+        state: absent
+        purge: true
     apt_deb_packages:
       - "https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_x86_64.deb"
     apt_mails:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,8 +27,10 @@
 apt_cache_valid_time: 3600
 # upgrade system: safe | full | dist
 apt_upgrade: no
-# packages to install
+# packages to ensure
 apt_packages: []
+# package state
+apt_package_state: 'present'
 # remove packages that are no longer needed for dependencies
 apt_autoremove: yes
 # remove .deb files for packages no longer on your system

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,7 +1,15 @@
 ---
 
-- name: Installing packages
+- name: Ensuring packages
   apt:
-    name: "{{ apt_packages }}"
-    state: present
+    name: "{{ (apt_package is mapping)|ternary(apt_package.name, apt_package) }}"
+    state: "{{ apt_package.state|default(apt_package_state) }}"
+    default_release: "{{ apt_package.default_release|default(omit) }}"
+    force: "{{ apt_package.force|default(omit) }}"
+    only_upgrade: "{{ apt_package.only_upgrade|default(omit) }}"
+    install_recommends: "{{ apt_package.install_recommends|default(apt_install_recommends) }}"
     autoremove: "{{ apt_autoremove }}"
+    purge: "{{ apt_package.purge|default(omit) }}"
+  with_items: "{{ apt_packages }}"
+  loop_control:
+    loop_var: apt_package


### PR DESCRIPTION
Allows setting of individual package parameters like: name, state, default_release, force, only_upgrade, install_recommends and purge. An array item contained in apt_packages can be a simple string (for backward compatibility) indicating the package to be installed or a dict/hash with keys mentioned above allowing fine-grained control over package presence or absence.

Signed-off-by: Christoph Fiehe <fiehe@gmx.de>