### PR TITLE
Adds apt-mark hold and unhold capability to tasks.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ This is an example playbook:
       - tree
       - name: ca-certificates
         state: latest
+        hold: true
       - name: zsh
         state: absent
         purge: true

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -13,7 +13,7 @@
       changed_when: false
 
     - name: Hold or unhold a package
-      command: "apt-mark {{ item.hold is sameas true | ternary('hold', 'install') }} {{ item.name }}"
+      command: "apt-mark {{ item.hold is sameas true | ternary('hold', 'unhold') }} {{ item.name }}"
       when: >
         (item.name not in apt_mark_held_packages.stdout and item.hold is sameas true)
         or (item.name in apt_mark_held_packages.stdout and item.hold is not sameas true)

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,5 +1,24 @@
 ---
 
+- name: Holding and unholding packages
+  block:
+    - name: Assemble a list of packages to hold or unhold
+      set_fact:
+        apt_mark_hold_packages: "{{ apt_packages | selectattr('hold', 'defined') | list }}"
+      changed_when: false
+
+    - name: Assemble a list of already-held packages
+      command: "apt-mark showhold"
+      register: apt_mark_held_packages
+      changed_when: false
+
+    - name: Hold or unhold a package
+      command: "apt-mark {{ item.hold is sameas true | ternary('hold', 'install') }} {{ item.name }}"
+      when: >
+        (item.name not in apt_mark_held_packages.stdout and item.hold is sameas true)
+        or (item.name in apt_mark_held_packages.stdout and item.hold is not sameas true)
+      with_items: "{{ apt_mark_hold_packages }}"
+
 - name: Ensuring packages
   apt:
     allow_unauthenticated: "{{ item.allow_unauthenticated | default(omit) }}"

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -11,6 +11,7 @@
       - tree
       - name: ca-certificates
         state: latest
+        hold: true
       - name: zsh
         state: absent
         purge: true


### PR DESCRIPTION
This is a relatively simple change, but is slightly hard reading. Here's my attempt to clarify :)

- We use a new _boolean_ property, `hold` on any `apt_packages` item (see `README.md` line 242); the property is boolean to make it simpler to do two things:
  1. set the value on the basis of facts on the server or created in earlier tasks,
  2. limit the allowable options (i.e. we don't give role consumers the option to choose `hold` or `unhold`)
- In `packages.yml`, we filter the `apt_packages` variable down to the items with a defined `hold` property (`tasks/packages.yml`, lines 5-8)
- Then, we use `apt-mark` via the `command` module to discover any already-held packages on the system (`tasks/packages.yml`, lines 10-13)
- Finally, we use the `command` module to run `apt-mark hold` or `apt-mark unhold` (`tasks/packages.yml`, lines 15-20), but only when one of two conditions is true:
  1. `item.hold` _is_ set to true, and `item.name` _wasn't_ found in the output of `apt-mark showhold`, **or**
  2. `item.hold` _is not_ set to true, and `item.name` _was_ found in the output of `apt-mark showhold`.
  
Further notes:
  
  - the new tasks test as properly idempotent,
  - it turned out to be simpler to use `command` with `apt-mark` directly than to use Ansible's `dpkg_selections` module since it doesn't have a simple `hold` / `unhold` binary,
  - the Ansible maintainers [have no intention of adding `apt-mark` support to the `apt` module](https://github.com/ansible/ansible/issues/18889)