### PR TITLE
Add option to create apt.conf.d files

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ apt_aptitude_solution_cost: []
 #     priority: 1001
 apt_preferences: []
 
+# List of apt configuration.
+# apt_conf_d:
+#   - file: 10options
+#     content: |
+#       # Managed by Ansible
+#       Dpkg::Options {
+#         "--force-confdef";
+#         "--force-confold";
+#       }
+apt_conf_d: []
+
 ```
 
 ## Handlers

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -151,3 +151,14 @@ apt_aptitude_solution_cost: []
 #     pin: "version 5.20*"
 #     priority: 1001
 apt_preferences: []
+
+# List of apt configuration.
+# apt_conf_d:
+#   - file: 10options
+#     content: |
+#       # Managed by Ansible
+#       Dpkg::Options {
+#         "--force-confdef";
+#         "--force-confold";
+#       }
+apt_conf_d: []

--- a/tasks/preferences.yml
+++ b/tasks/preferences.yml
@@ -8,3 +8,12 @@
     group: root
     mode: 0644
   with_items: "{{ apt_preferences }}"
+
+- name:  Configuring APT
+  copy:
+    content: "{{ item.content }}"
+    dest: "/etc/apt/apt.conf.d/{{ item.file }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items: "{{ apt_conf_d }}"


### PR DESCRIPTION
Hello,

Currently it is possible to create configuration files in `/etc/apt/preferences.d` but not in `/etc/apt/apt.conf.d`.  
The goal of this PR is to add this option.

The task has been added to `preferences.yml` to not create an additional file. Tell me if this file should be renamed or if I need to create a new one.

Thanks.