### PR TITLE
feat: add skip options for cache update, apt.conf.d templates, and policyrc.d

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,8 @@ apt_autoclean: yes
 # .deb packages to install.
 apt_deb_packages: []
 
+# manage general and periodic entries via template
+apt_general_periodic: true
 # https://people.debian.org/~hmh/invokerc.d-policyrc.d-specification.txt
 # skip config if less than 0 (-1=disable)
 apt_policy: 101

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ apt_autoclean: yes
 apt_deb_packages: []
 
 # https://people.debian.org/~hmh/invokerc.d-policyrc.d-specification.txt
+# skip config if less than 0 (-1=disable)
 apt_policy: 101
 # whether or not suggested packages should be installed.
 apt_install_suggests: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,8 @@ apt_dependencies:
   - aptitude
   - python3-apt
   - python3-pycurl
+# do cache update
+apt_update: true
 # sets the amount of time the cache is valid
 apt_cache_valid_time: 3600
 # upgrade system: safe | full | dist

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,6 +7,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
+  when: apt_general_periodic | bool
   with_items:
     - "etc/apt/apt.conf.d/10general"
     - "etc/apt/apt.conf.d/10periodic"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -68,3 +68,4 @@
     content: "exit {{ apt_policy }}"
     dest: /usr/sbin/policy-rc.d
     mode: "0755"
+  when: apt_policy | int >= 0

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -2,5 +2,5 @@
 
 - name: Updating cache
   apt:
-    update_cache: yes
+    update_cache: "{{ apt_update | bool }}"
     cache_valid_time: "{{ apt_cache_valid_time }}"

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -3,6 +3,6 @@
 - name: Upgrading system
   apt:
     upgrade: "{{ apt_upgrade }}"
-    update_cache: yes
+    update_cache: "{{ apt_update | bool }}"
     autoremove: "{{ apt_autoremove }}"
   when: (apt_upgrade == "safe") or (apt_upgrade == "full") or (apt_upgrade == "dist")


### PR DESCRIPTION
This PR refactors and extends skip conditions for APT-related tasks, introducing
clear, top-level control variables with explicit defaults.
Users can now enable or disable APT operations declaratively.

New Variables:
- apt_update
    Type: bool
    Default: true
    Purpose: Controls whether to run apt-get update and related cache-refresh operations.
    Behavior: When false, apt update and apt upgrade tasks performing cache updates are skipped.

- apt_general_periodic
    Type: bool
    Default: true
    Purpose: Enables or disables management of both general and periodic apt.conf.d templates.
    Behavior: When false, no templates `10general` and `10periodic` rendered under /etc/apt/apt.conf.d.

Change Variables:
- apt_policy
    Type: int
    Default: 101
    Purpose: Determines whether to manage policy priorities.
    Behavior: When value < 0, skips creation of /usr/sbin/policy-rc.d.

